### PR TITLE
fix: lazy-load SqliteProvider to avoid node:sqlite ExperimentalWarning

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ const { VirtualFileSystem } = require('./lib/file_system.js');
 const { VirtualProvider } = require('./lib/provider.js');
 const { MemoryProvider } = require('./lib/providers/memory.js');
 const { RealFSProvider } = require('./lib/providers/real.js');
-const { SqliteProvider } = require('./lib/providers/sqlite.js');
 
 /**
  * Creates a new VirtualFileSystem instance.
@@ -31,5 +30,21 @@ module.exports = {
   VirtualProvider,
   MemoryProvider,
   RealFSProvider,
-  SqliteProvider,
 };
+
+// Lazy-load SqliteProvider so that `node:sqlite` (and its ExperimentalWarning)
+// is only required when a consumer actually reads `vfs.SqliteProvider`.
+Object.defineProperty(module.exports, 'SqliteProvider', {
+  enumerable: true,
+  configurable: true,
+  get() {
+    const { SqliteProvider } = require('./lib/providers/sqlite.js');
+    Object.defineProperty(module.exports, 'SqliteProvider', {
+      value: SqliteProvider,
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+    return SqliteProvider;
+  },
+});


### PR DESCRIPTION
## Summary

- Make `SqliteProvider` a lazy getter on `module.exports` so `node:sqlite` is only required when a consumer actually reads `vfs.SqliteProvider`.
- Eliminates the process-wide `ExperimentalWarning: SQLite is an experimental feature` that was emitted on every `require('@platformatic/vfs')`, even for consumers that only use `MemoryProvider` / `RealFSProvider`.

## Why

`index.js` eagerly required `./lib/providers/sqlite.js`, which in turn imports `node:sqlite` at the top of the module. `node:sqlite` emits an `ExperimentalWarning` the first time it is loaded in a process. That meant:

- Any app using `@platformatic/vfs` printed the warning on startup, regardless of whether SQLite was used.
- The noise was especially visible in SEA / `pkg` binaries where `@platformatic/vfs` is loaded unconditionally during bootstrap.

The alternative fixes were weaker:

- Suppressing the warning at the consumer layer (e.g. in `pkg`'s `sea-bootstrap.js`) hides it but keeps the eager load — users still pay the `node:sqlite` startup cost, and non-SEA consumers still see the warning.
- Splitting into a subpath export (`@platformatic/vfs/sqlite`) is cleaner long-term but a breaking API change.

The lazy getter is zero API break: the export shape (`typeof vfs.SqliteProvider === 'function'`, enumerable on the object) is preserved, and the value is memoized on first access.

## Test plan

- [x] `node --test test/sqlite.test.js` — all 90 sqlite tests pass.
- [x] Manual repro:
  - `require('./index.js')` without touching `SqliteProvider` → no `ExperimentalWarning`.
  - Reading `vfs.SqliteProvider` → warning fires exactly once, as expected.
- [x] `eslint index.js` clean.