### PR TITLE
fix: update `VFSStatWatcher` typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -107,7 +107,9 @@ export class VFSWatchAsyncIterable implements AsyncIterable<WatchAsyncEvent> {
 }
 
 export class VFSStatWatcher extends EventEmitter {
+  // @ts-expect-error Implementation overrides the method
   addListener(listener: (curr: VirtualStats, prev: VirtualStats) => void): void;
+  // @ts-expect-error Implementation overrides the method
   removeListener(listener: (curr: VirtualStats, prev: VirtualStats) => void): boolean;
   hasNoListeners(): boolean;
   stop(): void;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
     "strict": true,
-    "module": "commonjs",
+    "module": "node16",
     "target": "es2022",
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "declaration": true,
     "esModuleInterop": true,
-    "baseUrl": ".",
+    "types": ["node"],
     "paths": {
       "@platformatic/vfs": ["."]
     }


### PR DESCRIPTION
This PR updates typings of the `VFSStatWatcher` class.

The problem is that `addListener()` and `removeListener()` are trying to override type declarations of `EventEmitter` with different implementations. For instance, `addListener()` declares one argument and a `void` return type, but the original declaration has two arguments and a `this` return type. TypeScript rejects the new declaration as incompatible, see https://github.com/microsoft/TypeScript/issues/6094.

This problem is reported in https://github.com/platformatic/vfs/pull/31. The newer version of TSTyche added checks for `.d.ts` files. The change should unblock the PR.

The types are correct and based on the current implementation: https://github.com/platformatic/vfs/blob/2882dd250f5f77facc17c9156c2e08ae3d293802/lib/watcher.js#L246-L256

## Solutions

The typings are correct. So I think using `@ts-expect-error` is ok solution.

Another good solution can be found in #33.

Alternatively, it is possible to disable the additional TSTyche checks. But users with `"skipLibCheck": false` set will see the error.

The error can be silenced by adding the original type declarations of `addListener()` and `removeListener()` as function overloads. But the typings would be incorrect, because methods of `VFSStatWatcher` do not take two arguments.

---

Close #33