### PR TITLE
feat: convert `Watcher` class declaration to interfaces

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -88,7 +88,7 @@ export class VirtualReadStream extends Readable {
   get path(): string;
 }
 
-export class VFSWatcher extends EventEmitter {
+export interface VFSWatcher extends EventEmitter {
   close(): void;
   unref(): this;
   ref(): this;
@@ -99,14 +99,14 @@ export interface WatchAsyncEvent {
   filename: string;
 }
 
-export class VFSWatchAsyncIterable implements AsyncIterable<WatchAsyncEvent> {
+export interface VFSWatchAsyncIterable extends AsyncIterable<WatchAsyncEvent> {
   [Symbol.asyncIterator](): AsyncIterator<WatchAsyncEvent>;
   next(): Promise<IteratorResult<WatchAsyncEvent>>;
   return(): Promise<IteratorResult<WatchAsyncEvent>>;
   throw(error?: unknown): Promise<IteratorResult<WatchAsyncEvent>>;
 }
 
-export class VFSStatWatcher extends EventEmitter {
+export interface VFSStatWatcher extends Omit<EventEmitter, 'addListener' | 'removeListener'> {
   addListener(listener: (curr: VirtualStats, prev: VirtualStats) => void): void;
   removeListener(listener: (curr: VirtualStats, prev: VirtualStats) => void): boolean;
   hasNoListeners(): boolean;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
     "strict": true,
-    "module": "commonjs",
+    "module": "node16",
     "target": "es2022",
-    "moduleResolution": "node",
+    "moduleResolution": "node16",
     "declaration": true,
     "esModuleInterop": true,
-    "baseUrl": ".",
+    "types": ["node"],
     "paths": {
       "@platformatic/vfs": ["."]
     }


### PR DESCRIPTION
Alternative to #32

This PR converts the `Watcher` class declaration to interfaces.

As explained in #32, currently TypeScript reports declarations of `addListener()` and `removeListener()` as incompatible with the original class (see #31). When a class is converted into an interface, it is possible to use `Omit<EventEmitter, 'addListener' | 'removeListener'>`. This solves the problem.

The only difference for a user is that it will not be possible to use `new` on `VFSStatWatcher` and other classes. These classes are not exported from `index.js`. The type declaration model the return types of `watch()`, `watchFile()`, and `watchAsync()`. So that shouldn’t be a problem.

I suggest converting all three classes so that the return typings of all three watch methods are consistently modelled using interfaces.

---

Close #32