### PR TITLE
fix: the bump-version in bump-version.ts

### DIFF
--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S node
 
-import { execSync } from 'node:child_process'
+import { execFileSync } from 'node:child_process'
 import { readFile, writeFile } from 'node:fs/promises'
 import { inc, type ReleaseType } from 'semver'
 
@@ -47,8 +47,8 @@ const version = await getVersion()
 await updatePackageJson(version)
 
 if (process.env.GITHUB_ACTIONS === 'true') {
-  execSync(`git config --global user.name "${userInfo[0]}"`)
-  execSync(`git config --global user.email "${userInfo[1]}"`)
+  execFileSync('git', ['config', '--global', 'user.name', userInfo[0]])
+  execFileSync('git', ['config', '--global', 'user.email', userInfo[1]])
 }
 
-execSync(`git commit -a -m "chore: Bumped v${version}." -m "Signed-off-by: ${userInfo[0]} <${userInfo[1]}>"`)
+execFileSync('git', ['commit', '-a', '-m', `chore: Bumped v${version}.`, '-m', `Signed-off-by: ${userInfo[0]} <${userInfo[1]}>`])


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `scripts/bump-version.ts`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `scripts/bump-version.ts:10` |
| **Assessment** | Likely exploitable |

**Description**: The bump-version.ts script uses execSync() to execute shell commands with user-controlled input. The username from process.argv[3] or process.env.GITHUB_ACTOR is used to look up user information, which is then interpolated directly into shell commands via template literals. If an attacker controls GITHUB_ACTOR environment variable or process.argv[3], they can inject arbitrary shell commands through the userInfo values that get interpolated into git config and git commit commands.

## Evidence

**Exploitation scenario**: An attacker who can set the GITHUB_ACTOR environment variable (e.g., through CI/CD pipeline configuration, compromised environment, or fork-based pull request attacks) sets it to a malicious value.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `scripts/bump-version.ts`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-001 scanner=multi_agent_ai -->
