### PR TITLE
chore: Use default token for release notes.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,5 +48,7 @@ jobs:
       - name: Publish to NPM
         run: pnpm publish --access public --tag ${{ inputs.prerelease == true && 'next' || 'latest' }} --publish-branch ${{ github.ref_name }} --no-git-checks
       - name: "Create release notes"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          pnpx @matteo.collina/release-notes -a ${{ secrets.GH_RELEASE_TOKEN }} -t v${{ inputs.version }} -o platformatic -r vfs ${{ github.event.inputs.prerelease == 'true' && '-p' || '' }} -c ${{ github.ref }}
+          pnpx @matteo.collina/release-notes -t v${{ inputs.version }} -o platformatic -r vfs ${{ github.event.inputs.prerelease == 'true' && '-p' || '' }} -c ${{ github.ref }}


### PR DESCRIPTION
## Summary
Use the default GitHub Actions token for release notes and release operations.

## Changes
- Set `GITHUB_TOKEN` from `${{ github.token }}` in the release notes step.
- Remove the explicit `-a` token argument and external release token references.
- Ensure the release job has `contents: write` and `id-token: write` permissions.

Assisted-By: OpenAI:gpt-5.6-luna <openai/gpt-5.6-luna>